### PR TITLE
Added basic Python Flask app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,84 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Virtual environment
+env/
+
+# Environment variables
+.env
+
+# macOS files
+.DS_Store
+
+# Backup files
+*.bak
+*.swp
+
+# Python egg files
+*.egg
+*.egg-info/
+dist/
+build/
+eggs/
+parts/
+bin/
+var/
+sdist/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg-info/
+
+# PyInstaller
+#  Usually these files are written by a Python script from a template
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+pytest_cache/
+cover/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# Flask specific
+instance/
+web_app.db
+
+# Logs
+logs/
+*.log
+*.out
+*.err
+
+# Local development
+local_settings.py

--- a/waldogpt/__init__.py
+++ b/waldogpt/__init__.py
@@ -1,0 +1,12 @@
+"""WaldoGPT package installer."""
+import flask
+
+app = flask.Flask(__name__)
+
+app.config.from_object('waldogpt.config')
+
+app.config.from_envvar('WALDOGPT_SETTINGS', silent=True)
+
+# import waldogpt.views
+# import waldogpt.models
+import waldogpt.index

--- a/waldogpt/config.py
+++ b/waldogpt/config.py
@@ -1,0 +1,11 @@
+"""WaldoGPT development configuration."""
+# from dotenv import load_dotenv
+import pathlib
+
+# load_dotenv()
+
+APPLICATION_ROOT = '/'
+
+# Secret key for encrypting cookies
+# SECRET_KEY = os.getenv("SESSION_KEY")
+SESSION_COOKIE_NAME = 'login'

--- a/waldogpt/index.py
+++ b/waldogpt/index.py
@@ -1,0 +1,6 @@
+import flask
+import waldogpt
+
+@waldogpt.app.route('/')
+def index():
+    return "<p>Hello, world!</p>"


### PR DESCRIPTION
Implemented the start of our python flask app. 

Soon I will create some scripts to make it easy to setup for development.

Flask app is setup as a python package (directory with a __init__.py file). 
To setup: 
1. fetch the waldogpt directory and its contents.
2. use python 3.12.X and run `$ python3.12 -m venv env` this creates a virtual environment so that the python dependencies installed are specific to this project
3. run `$ source env/bin/activate` You should always run this when using this flask app. (use `deactivate` to end the venv)
4. run `$ pip3.12 install flask python-dotenv`
5. run `$ python3.12 -m flask --app waldogpt run`
6. Use the address and port from your terminal to view the app. (As of this PR it will be a Hello, World! message)

